### PR TITLE
On peut dorénavant modifier des vertices en run time

### DIFF
--- a/OpenGLProject/src/Managers/BatchRenderer/BatchRenderer.cpp
+++ b/OpenGLProject/src/Managers/BatchRenderer/BatchRenderer.cpp
@@ -112,6 +112,21 @@ void BatchRenderer::UpdateModelDatas(Model* model,ShaderType shaderType)
     }
 }
 
+void BatchRenderer::UpdateVerticesDatas(Model* model, ShaderType shaderType)
+{
+    for (const auto& shaderData : m_ShadersData[shaderType])
+    {
+        for (const auto& modelD : shaderData->m_Models)
+        {
+            if (model == modelD)
+            {
+                shaderData->UpdateModelVerticesDatas(model);
+                return;
+            }
+        }
+    }
+}
+
 int BatchRenderer::GetNextIndexToBindTextureTo(const ShaderType shaderType)
 {
     const int index = m_IndexTextures[shaderType];

--- a/OpenGLProject/src/Managers/BatchRenderer/BatchRenderer.h
+++ b/OpenGLProject/src/Managers/BatchRenderer/BatchRenderer.h
@@ -45,6 +45,11 @@ class BatchRenderer
          */
         void UpdateModelDatas(Model* model, ShaderType shaderType);
 
+        /*
+         * Method to call when the vertices of a model are updated
+         */
+        void UpdateVerticesDatas(Model* model, ShaderType shaderType);
+
     private:
 
         /* Keep track of the current available texture slot for each shader */

--- a/OpenGLProject/src/Managers/BatchRenderer/ShaderBuffer/ShaderBuffer.cpp
+++ b/OpenGLProject/src/Managers/BatchRenderer/ShaderBuffer/ShaderBuffer.cpp
@@ -41,6 +41,7 @@ void ShadersBuffer::AddNewMesh(Mesh* mesh, Model* model)
     InsertIndices(mesh);
     
     m_Vertices.insert(m_Vertices.end(), mesh->m_Vertices.begin(), mesh->m_Vertices.end());
+    m_ModelsVertices[model].insert(m_ModelsVertices[model].end(), mesh->m_Vertices.begin(), mesh->m_Vertices.end());
     
     // if the model is not already in the list, add it ( Since a model can have multiple meshes )
     if (std::ranges::find_if(m_Models, [model](const Model* m) { return m == model; }) == m_Models.end())
@@ -64,7 +65,7 @@ void ShadersBuffer::Init()
     }
     
     InitTextureUniform();
-}
+} 
 
 std::vector<TransformData>& ShadersBuffer::GetAllTransformsData()
 {
@@ -121,6 +122,35 @@ void ShadersBuffer::ExtractModelTransformData(const std::vector<Model*>::value_t
     }
 
     m_NeedToRegroupTransformsAgain = true;
+}
+
+void ShadersBuffer::UpdateModelVerticesDatas(Model* model)
+{
+    if (m_ModelsVertices.contains(model))
+    {
+        m_ModelsVertices[model].clear();
+    }
+    
+    for (const auto& mesh : model->m_Meshes)
+    {
+        if (m_ModelsVertices.contains(model))
+        {
+            m_ModelsVertices[model].insert(m_ModelsVertices[model].end(), mesh->m_Vertices.begin(), mesh->m_Vertices.end());
+        }
+        else
+        {
+            m_ModelsVertices[model] = mesh->m_Vertices;
+        }
+    }
+    
+    m_Vertices.clear();
+
+    for (const auto& [model, vertices] : m_ModelsVertices)
+    {
+        m_Vertices.insert(m_Vertices.end(), vertices.begin(), vertices.end());
+    }
+
+    m_VBO->SetDatas(m_Vertices);
 }
 
 void ShadersBuffer::InitTextureUniform()

--- a/OpenGLProject/src/Managers/BatchRenderer/ShaderBuffer/ShaderBuffer.h
+++ b/OpenGLProject/src/Managers/BatchRenderer/ShaderBuffer/ShaderBuffer.h
@@ -57,6 +57,11 @@ struct ShadersBuffer
          void ExtractModelTransformData(const std::vector<Model*>::value_type& model);
 
         /*
+         * Update the vertices of the model in the buffer
+         */
+        void UpdateModelVerticesDatas(Model* model);
+ 
+        /*
          * Set the textures uniforms and bind the textures to the shader
          * Need to be called for each draw since we can have multiple draw with the same shader
          */
@@ -82,6 +87,8 @@ struct ShadersBuffer
 
         /* List of transform data for each mesh of the buffer that will be send to the shader by the SSBO */
         std::unordered_map<Model*, std::vector<TransformData>> m_ModelsTransforms;
+
+        std::unordered_map<Model*, std::vector<Vertex>> m_ModelsVertices;
 
         std::vector<TransformData>& GetAllTransformsData();
  

--- a/OpenGLProject/src/OpenGL/VertexBuffer/VertexBuffer.cpp
+++ b/OpenGLProject/src/OpenGL/VertexBuffer/VertexBuffer.cpp
@@ -23,13 +23,18 @@ Vertex::Vertex(const Vec3<float>& position)
 {
 }
 
-VertexBuffer::VertexBuffer(const std::vector<Vertex>& vertices) : m_Vertices(vertices), m_ID(0)
+void VertexBuffer::SetDatas(const std::vector<Vertex>& vertices)
 {
     glGenBuffers(1, &m_ID);
     
     Bind();
 
     glBufferData(GL_ARRAY_BUFFER, vertices.size() * sizeof(Vertex), vertices.data(), GL_STATIC_DRAW);
+}
+
+VertexBuffer::VertexBuffer(const std::vector<Vertex>& vertices) : m_Vertices(vertices), m_ID(0)
+{
+    SetDatas(vertices);
 }
 
 VertexBuffer::~VertexBuffer()

--- a/OpenGLProject/src/OpenGL/VertexBuffer/VertexBuffer.h
+++ b/OpenGLProject/src/OpenGL/VertexBuffer/VertexBuffer.h
@@ -26,6 +26,7 @@ class VertexBuffer
 
 		void Bind() const;
 		void Unbind() const;
+		void SetDatas(const std::vector<Vertex>& vertices);
 
 		std::vector<Vertex> m_Vertices;
 	


### PR DESCRIPTION
Il faut utiliser : void UpdateVerticesDatas(Model* model, ShaderType shaderType)

de la classe Batch renderer